### PR TITLE
Lisätään jkry.org hyväksyttyjen yhdistysten listaan

### DIFF
--- a/email_validation_policy.py
+++ b/email_validation_policy.py
@@ -17,7 +17,7 @@ EDU_DOMAINS = SCHOOL_DOMAINS + ['prakticum.fi', 'aalto.fi', 'abo.fi', 'arcada.fi
                                 'taitajantie.fi', 'tamk.fi', 'teak.fi', 'tiedenorssi.fi', 'tpu.fi', 'tukkk.fi',
                                 'tuni.fi', '*.turkuamk.fi', 'tut.fi', 'tyk.fi', 'uef.fi', 'uku.fi', 'ulapland.fi',
                                 'uniarts.fi', 'uta.fi', 'utu.fi', 'uwasa.fi', 'vamk.fi', 'xamk.fi', 'edu.tampere.fi']
-RY_DOMAINS = ["kapsi.fi", "hacklab.fi", "nullroute.fi", 'iki.fi', "fixme.fi", "far.fi", "modeemi.fi"]
+RY_DOMAINS = ["kapsi.fi", "hacklab.fi", "nullroute.fi", 'iki.fi', "fixme.fi", "far.fi", "modeemi.fi", "jkry.org"]
 ISP_DOMAINS = ["*.inet.fi", "kolumbus.fi", "elisanet.fi", "saunalahti.fi", "netti.fi", "nic.fi", "netikka.fi", "sci.fi",
                "anvianet.fi", "kymp.net", "jippii.fi", "kotinet.com", "eunet.fi", "welho.com", "mailsuomi.com"]
 CITY_DOMAINS = ["hel.fi", "vaasa.fi", "tampere.fi", "*.ouka.fi", "turku.fi", "kaarina.fi", "kokkola.fi", "hyvinkaa.fi",


### PR DESCRIPTION
> Järjestäytyneet Verkkokäyttäjät - JK ry on perustettu loppuvuodesta 2009 ja sen syvin tarkoitus on edistää jäseniensä mahdollisuuksia toteuttaa itseään tietoverkoissa. Tätä tarkoitusta varten yhdistys pyrkii tarjoamaan mahdollisimman joustavasti jäsenilleen verkkopalveluita. Yhdistys ei tavoittele taloudellista voittoa. Yhdistyksen säännöt löydät [täältä](https://www.jkry.org/saannot/).

Lisätietoa yhdistyksestä https://jkry.org/