### PR TITLE
edu.lao.fi muuttaminen edu.redu.fi

### DIFF
--- a/email_validation_policy.py
+++ b/email_validation_policy.py
@@ -2,7 +2,7 @@ import re
 SCHOOL_DOMAINS = ["kotka.opit.fi"]
 EDU_DOMAINS = SCHOOL_DOMAINS + ['prakticum.fi', 'aalto.fi', 'abo.fi', 'arcada.fi', 'bc.fi', 'centria.fi', 'cou.fi',
                                 'diak.fi', 'edu.bc.fi', 'edu.espoo.fi', 'edu.hel.fi', 'edu.hyria.fi', 'edu.kokkola.fi',
-                                'edu.kotka.fi', 'edu.kuopio.fi', 'edu.lahti.fi', 'edu.lao.fi', 'edu.lohja.fi',
+                                'edu.kotka.fi', 'edu.kuopio.fi', 'edu.lahti.fi', 'edu.redu.fi', 'edu.lohja.fi',
                                 'edu.loimaa.fi', 'edu.nivala.fi', 'edu.novia.fi', 'edu.raseko.fi', 'edu.riveria.fi',
                                 'edu.siikalatva.fi', 'edu.turku.fi', 'edu.tuusula.fi', 'edu.ylojarvi.fi', 'eduespoo.fi',
                                 'eduouka.fi', 'eduvammalanlukio.fi', 'evtek.fi', 'gradia.fi', 'haaga-helia.fi',


### PR DESCRIPTION
LAO:ta (Lapin Ammattiopistoa) ei enää ole, opiskelijoiden spostit nykyään "@edu.redu.fi"