### PR TITLE
Update email_validation_policy.py / Pyyntö lisätä suomalaisen c1.fi sähköpostipalvelun tarjoamat domain-tunnukset

### DIFF
--- a/email_validation_policy.py
+++ b/email_validation_policy.py
@@ -19,7 +19,8 @@ EDU_DOMAINS = SCHOOL_DOMAINS + ['prakticum.fi', 'aalto.fi', 'abo.fi', 'arcada.fi
                                 'uniarts.fi', 'uta.fi', 'utu.fi', 'uwasa.fi', 'vamk.fi', 'xamk.fi', 'edu.tampere.fi']
 RY_DOMAINS = ["kapsi.fi", "hacklab.fi", "nullroute.fi", 'iki.fi', "fixme.fi", "far.fi", "modeemi.fi", "jkry.org"]
 ISP_DOMAINS = ["*.inet.fi", "kolumbus.fi", "elisanet.fi", "saunalahti.fi", "netti.fi", "nic.fi", "netikka.fi", "sci.fi",
-               "anvianet.fi", "kymp.net", "jippii.fi", "kotinet.com", "eunet.fi", "welho.com", "mailsuomi.com"]
+               "anvianet.fi", "kymp.net", "jippii.fi", "kotinet.com", "eunet.fi", "welho.com", "mailsuomi.com",
+               "c1.fi", "g1.fi", "interconnect.fi", "intc.fi", "mex.fi"]
 CITY_DOMAINS = ["hel.fi", "vaasa.fi", "tampere.fi", "*.ouka.fi", "turku.fi", "kaarina.fi", "kokkola.fi", "hyvinkaa.fi",
                 "jarvenpaa.fi", "toivakka.fi", "jyvaskyla.fi", "kuopio.fi"]
 


### PR DESCRIPTION
c1.fi on uusi suomalainen, Suomessa hostattu levossa salaava sähköpostipalvelu.  Palvelun kuvaus ja tietoja (tämä englanniksi, lisään suomenkielisen version pian):

* https://c1.fi/v/matax/about/en

Lista käytössä olevista domain-tunnuksista esillä myös osoitteessa:  https://c1.fi/v/matax/details/en ("Email domains").

Palvelun tuottamisesta vastaa Fennosys Oy: https://fennosys.fi (allekirjoittaneen yritys).